### PR TITLE
Introduce explicit JsonConverter to comply with strict_date_format defined in mappings

### DIFF
--- a/src/AspNetCore.Identity.Elastic/AspNetCore.Identity.Elastic.csproj
+++ b/src/AspNetCore.Identity.Elastic/AspNetCore.Identity.Elastic.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.1" />
     <PackageReference Include="NEST" Version="5.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore.Identity.Elastic/ElasticClientFactory.cs
+++ b/src/AspNetCore.Identity.Elastic/ElasticClientFactory.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Nest;
+using Elasticsearch.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+[assembly: InternalsVisibleTo("AspNetCore.Identity.Elastic.Tests")]
+namespace AspNetCore.Identity.Elastic
+{    
+    internal static class ElasticClientFactory
+    {
+        public static IElasticClient Create(Uri node, string defaultIndex)
+        {
+            var settings = new ConnectionSettings(
+                new SingleNodeConnectionPool(node),
+                new HttpConnection(),
+                new SerializerFactory(DefineSerializationSettings));
+
+            settings.MapDefaultTypeIndices(m => m
+                .Add(typeof(ElasticIdentityUser), defaultIndex));
+
+            var transport = new Transport<IConnectionSettingsValues>(settings);
+            
+            return new ElasticClient(settings);
+        }
+
+        private static void DefineSerializationSettings(
+            JsonSerializerSettings jsonSerializerSettings,
+            IConnectionSettingsValues connectionSettingsValues)
+        {
+            //Since we use strict_date_time format in our elasticsearch mappings for all dates, we 
+            //need to ensure that serialized dates match that format. The format defined below 
+            //is based on strict_date_time in elasticsearch version 5.3.0. 
+            //documentation @ https://www.elastic.co/guide/en/elasticsearch/reference/5.3/mapping-date-format.html
+            var dateTimeConverter = new IsoDateTimeConverter
+            {
+                DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffZ",
+                DateTimeStyles = DateTimeStyles.AdjustToUniversal
+            };
+
+            if (jsonSerializerSettings.Converters == null)
+            {
+                jsonSerializerSettings.Converters = new List<JsonConverter>();
+            }
+
+            jsonSerializerSettings.Converters.Add(dateTimeConverter);
+        }
+    }
+}

--- a/src/AspNetCore.Identity.Elastic/Extensions/ServiceExtensions.cs
+++ b/src/AspNetCore.Identity.Elastic/Extensions/ServiceExtensions.cs
@@ -28,11 +28,9 @@ namespace AspNetCore.Identity.Elastic.Extensions
         public static void AddElasticIdentity(this IServiceCollection services, string serverName, string indexName = DEFAULT_INDEX_NAME)
         {
             var node = new Uri("http://" + serverName.Replace("http://", ""));
-            var settings = new ConnectionSettings(node);
-            settings.MapDefaultTypeIndices(m => m
-                .Add(typeof(ElasticIdentityUser), indexName));
-            var elasticClient = new ElasticClient(settings);
 
+            IElasticClient elasticClient = ElasticClientFactory.Create(node, indexName);
+            
             AddElasticIdentity(services, elasticClient);
         }
     }

--- a/tests/AspNetCore.Identity.Elastic.Tests/ElasticUserStoreTest.cs
+++ b/tests/AspNetCore.Identity.Elastic.Tests/ElasticUserStoreTest.cs
@@ -12,7 +12,7 @@ namespace AspNetCore.Identity.Elastic.Tests
     public class ElasticUserStoreTest : IDisposable
     {
         private readonly ElasticUserStore _store;
-        private readonly ElasticClient _elasticClient;
+        private readonly IElasticClient _elasticClient;
 
         private readonly ElasticIdentityUser _user1 = new ElasticIdentityUser("user1")
         {
@@ -29,10 +29,9 @@ namespace AspNetCore.Identity.Elastic.Tests
         public ElasticUserStoreTest()
         {
             _indexName = Guid.NewGuid() + "users";
-            var node = new Uri("http://127.0.0.1:9200");
-            var settings = new ConnectionSettings(node);
-            settings.MapDefaultTypeIndices(m => m.Add(typeof(ElasticIdentityUser), _indexName));
-            _elasticClient = new ElasticClient(settings);
+            var node = new Uri("http://localhost:9200");
+
+            _elasticClient = ElasticClientFactory.Create(node, _indexName);
 
             _store = new ElasticUserStore(_elasticClient);
 


### PR DESCRIPTION
This change assumes direct control of ElasticClient generation in order to introduce a new IsoDateTimeConverter which forces dates to match the format yyyy-MM-ddTHH:mm:ss.fffZ.

Without this change, dates are serialized like so:
2017-04-06T11:25:35.6444179+00:00
This does not comply with the strict_date_time format which is attributed on to DateTimeOffset properties in ElasticUserIdentity.cs.

I have also extracted the client generation logic out in to a factory which is now also used by the tests to generate an ElasticClient.