### PR TITLE
Fix serialised datetime format being incompatible with strict_date_time when no milliseconds are present.

### DIFF
--- a/src/AspNetCore.Identity.Elastic/ElasticClientFactory.cs
+++ b/src/AspNetCore.Identity.Elastic/ElasticClientFactory.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using Nest;
 using Elasticsearch.Net;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 [assembly: InternalsVisibleTo("AspNetCore.Identity.Elastic.Tests")]
 namespace AspNetCore.Identity.Elastic
@@ -31,15 +29,7 @@ namespace AspNetCore.Identity.Elastic
             JsonSerializerSettings jsonSerializerSettings,
             IConnectionSettingsValues connectionSettingsValues)
         {
-            //Since we use strict_date_time format in our elasticsearch mappings for all dates, we 
-            //need to ensure that serialized dates match that format. The format defined below 
-            //is based on strict_date_time in elasticsearch version 5.3.0. 
-            //documentation @ https://www.elastic.co/guide/en/elasticsearch/reference/5.3/mapping-date-format.html
-            var dateTimeConverter = new IsoDateTimeConverter
-            {
-                DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffZ",
-                DateTimeStyles = DateTimeStyles.AdjustToUniversal
-            };
+            var dateTimeConverter = new UtcIsoDateTimeConverter();
 
             if (jsonSerializerSettings.Converters == null)
             {
@@ -47,6 +37,8 @@ namespace AspNetCore.Identity.Elastic
             }
 
             jsonSerializerSettings.Converters.Add(dateTimeConverter);
+
+            jsonSerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
         }
     }
 }

--- a/src/AspNetCore.Identity.Elastic/ElasticIdentityUser.cs
+++ b/src/AspNetCore.Identity.Elastic/ElasticIdentityUser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Nest;
+using Newtonsoft.Json;
 
 namespace AspNetCore.Identity.Elastic
 {
@@ -70,18 +71,23 @@ namespace AspNetCore.Identity.Elastic
         public bool IsTwoFactorEnabled { get; set; }
 
         [Date(Format = ISO_DATE_FORMAT)]
+        [JsonConverter(typeof(UtcIsoDateTimeConverter))]
         public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
 
         [Date(Format = ISO_DATE_FORMAT)]
+        [JsonConverter(typeof(UtcIsoDateTimeConverter))]
         public DateTimeOffset? DateDeleted { get; set; } = null;
 
         [Date(Format = ISO_DATE_FORMAT)]
+        [JsonConverter(typeof(UtcIsoDateTimeConverter))]
         public DateTimeOffset? LastLoginDate { get; set; } = null;
 
         [Date(Format = ISO_DATE_FORMAT)]
+        [JsonConverter(typeof(UtcIsoDateTimeConverter))]
         public DateTimeOffset? LastPasswordChangedDate { get; set; } = null;
 
         [Date(Format = ISO_DATE_FORMAT)]
+        [JsonConverter(typeof(UtcIsoDateTimeConverter))]
         public DateTimeOffset? LockoutEndDate { get; set; }
 
         [Nested(IncludeInParent = true)]

--- a/src/AspNetCore.Identity.Elastic/ElasticUserStore.cs
+++ b/src/AspNetCore.Identity.Elastic/ElasticUserStore.cs
@@ -25,12 +25,12 @@ namespace AspNetCore.Identity.Elastic
         {
         }
 
-        public ElasticUserStore(IElasticClient elasticClient, ElasticOptions options)
+        public ElasticUserStore(IElasticClient elasticClient, ElasticUserStoreOptions options)
             : base(elasticClient, options)
         {
         }
 
-        public ElasticUserStore(IElasticClient elasticClient, IOptions<ElasticOptions> options)
+        public ElasticUserStore(IElasticClient elasticClient, IOptions<ElasticUserStoreOptions> options)
             : base(elasticClient, options)
         {
         }
@@ -168,7 +168,7 @@ namespace AspNetCore.Identity.Elastic
 
             ElasticClient = elasticClient;
 
-            Options = new ElasticOptions
+            Options = new ElasticUserStoreOptions
             {
                 IndexName = indexName
             };
@@ -183,12 +183,12 @@ namespace AspNetCore.Identity.Elastic
         {
         }
 
-        public ElasticUserStore(IElasticClient elasticClient, IOptions<ElasticOptions> options)
+        public ElasticUserStore(IElasticClient elasticClient, IOptions<ElasticUserStoreOptions> options)
             : this(elasticClient, options.Value)
         {
         }
 
-        public ElasticUserStore(IElasticClient elasticClient, ElasticOptions options)
+        public ElasticUserStore(IElasticClient elasticClient, ElasticUserStoreOptions options)
         {
 
             if (elasticClient == null)
@@ -222,7 +222,7 @@ namespace AspNetCore.Identity.Elastic
 
         protected IElasticClient ElasticClient { get; }
 
-        public ElasticOptions Options { get; set; }
+        public ElasticUserStoreOptions Options { get; set; }
 
         public IQueryable<TUser> Users
         {

--- a/src/AspNetCore.Identity.Elastic/ElasticUserStoreOptions.cs
+++ b/src/AspNetCore.Identity.Elastic/ElasticUserStoreOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace AspNetCore.Identity.Elastic
 {
-    public class ElasticOptions
+    public class ElasticUserStoreOptions
     {
         private const int DEFAULT_QUERY_SIZE = 10000;
         private const int NUMBER_OF_SHARDS = 1;

--- a/src/AspNetCore.Identity.Elastic/Extensions/ServiceExtensions.cs
+++ b/src/AspNetCore.Identity.Elastic/Extensions/ServiceExtensions.cs
@@ -8,11 +8,25 @@ namespace AspNetCore.Identity.Elastic.Extensions
 {
     public static class ServiceExtensions
     {
-        private const string DEFAULT_INDEX_NAME = "users";
+        private const string DEFAULT_INDEX_NAME = "users";        
 
-        public static void AddElasticIdentity(this IServiceCollection services, IElasticClient elasticClient)
+        /// <summary>
+        /// Registers singleton <see cref="ElasticUserStore"/> component for 
+        /// <see cref="IUserStore{ElasticIdentityUser}"/> with the parameters supplied by the provided 
+        /// <see cref="ElasticUserStoreOptions"/>, and registers dependencies for that component which have not already been 
+        /// registered.
+        /// </summary>
+        /// <param name="elasticClient">
+        /// The <see cref="IElasticClient"/> which will be used by the <see cref="ElasticUserStore"/>.
+        /// </param>
+        public static void AddElasticIdentity(
+            this IServiceCollection services, 
+            IElasticClient elasticClient)
         {
-            services.AddSingleton<IUserStore<ElasticIdentityUser>>(provider => new ElasticUserStore(elasticClient));
+            services.TryAddSingleton<IElasticClient>(elasticClient);
+
+            services.AddSingleton<IUserStore<ElasticIdentityUser>, ElasticUserStore>();
+
             services.TryAddSingleton<IdentityMarkerService>();
             services.TryAddSingleton<IUserValidator<ElasticIdentityUser>, UserValidator<ElasticIdentityUser>>();
             services.TryAddSingleton<IPasswordValidator<ElasticIdentityUser>, PasswordValidator<ElasticIdentityUser>>();
@@ -25,9 +39,24 @@ namespace AspNetCore.Identity.Elastic.Extensions
             services.TryAddScoped<SignInManager<ElasticIdentityUser>, SignInManager<ElasticIdentityUser>>();
         }
 
-        public static void AddElasticIdentity(this IServiceCollection services, string serverName, string indexName = DEFAULT_INDEX_NAME)
+        /// <summary>
+        /// Registers singleton <see cref="ElasticUserStore"/> component for 
+        /// <see cref="IUserStore{ElasticIdentityUser}"/> with the parameters supplied by the provided 
+        /// <see cref="ElasticUserStoreOptions"/>, and registers dependencies for that component which have not already been 
+        /// registered.
+        /// </summary>
+        /// <param name="serverName">
+        /// The server:port combination which the <see cref="ElasticUserStore"/> will connect to. E.g. localhost:9200
+        /// </param>
+        /// <param name="indexName">
+        /// The index which will contain the user information.
+        /// </param>
+        public static void AddElasticIdentity(
+            this IServiceCollection services, 
+            string serverName, 
+            string indexName = DEFAULT_INDEX_NAME)
         {
-            var node = new Uri("http://" + serverName.Replace("http://", ""));
+            var node = new Uri("http://" + serverName.Replace("http://", ""));            
 
             IElasticClient elasticClient = ElasticClientFactory.Create(node, indexName);
             

--- a/src/AspNetCore.Identity.Elastic/UtcIsoDateTimeConverter.cs
+++ b/src/AspNetCore.Identity.Elastic/UtcIsoDateTimeConverter.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AspNetCore.Identity.Elastic.Tests")]
+namespace AspNetCore.Identity.Elastic
+{
+    internal class UtcIsoDateTimeConverter : IsoDateTimeConverter
+    {
+        //Since we use strict_date_time format in our elasticsearch mappings for all dates, we 
+        //need to ensure that serialized dates match that format. The format defined below 
+        //is based on strict_date_time in elasticsearch version 5.3.0. 
+        //documentation @ https://www.elastic.co/guide/en/elasticsearch/reference/5.3/mapping-date-format.html
+        public const string UTC_FORMAT = "yyyy-MM-ddTHH:mm:ss.fffffffzz";
+
+        public UtcIsoDateTimeConverter()
+        {
+            //Forcibly override the datetime format with our own, as the default datetime format used in 
+            //IsoDateTimeConverter uses a format () which trims the milliseconds portion of the datetime string 
+            //if they're all zeroes, causing a parse failure when attempting to write to the date fields in the 
+            //user index due to the strict_date_time format specified on the mapping.
+            DateTimeFormat = UTC_FORMAT;
+            
+            //We're dealing in Utc everywhere, so assume that. This might be a failure point if that's ever 
+            //not a safe assumption to make.
+            DateTimeStyles = DateTimeStyles.AdjustToUniversal;
+        }
+        
+        public override bool CanRead => true;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return base.ReadJson(reader, objectType, existingValue, serializer);
+        }
+
+        public override bool CanWrite => true;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            string text;
+
+            switch (value)
+            {
+                case DateTimeOffset v:
+                    DateTimeOffset datetimeOffset = ((DateTimeOffset)value).ToUniversalTime();
+                    text = datetimeOffset.ToString(UTC_FORMAT);
+                    break;
+                case DateTime v:
+                    DateTime datetime = ((DateTime)value).ToUniversalTime();
+                    text = datetime.ToString(UTC_FORMAT);
+                    break;
+                default:
+                    base.WriteJson(writer, value, serializer);
+                    return;
+            }
+
+            writer.WriteValue(text);
+        }
+    }
+}


### PR DESCRIPTION
Fix serialised datetime format being incompatible with strict_date_time when no milliseconds are present.
Rename ElasticOptions to ElasticUserStoreOptions to reflect usage context.
Introduce unit tests around UpdateAsync() and datetime serialisation.